### PR TITLE
Use db clock to create the created_at timestamps

### DIFF
--- a/api/app/datastores/db/schemas.py
+++ b/api/app/datastores/db/schemas.py
@@ -38,13 +38,13 @@ class UserBase(BaseModel):
     username: str
     email: str
 
-    created_at: datetime.datetime
-    updated_at: Optional[datetime.datetime] = None
-
 
 class User(UserBase):
     id: int
     urls: List[Url] = []
+
+    created_at: datetime.datetime
+    updated_at: Optional[datetime.datetime] = None
 
     class Config:
         orm_mode = True

--- a/api/app/routers/auth.py
+++ b/api/app/routers/auth.py
@@ -50,7 +50,7 @@ async def login(code: Optional[str] = None, state: Optional[str] = None, db: Ses
 
         user_data = res.json()
 
-        user = UserCreate(username=user_data['login'], email=user_data['email'], created_at=datetime.now())
+        user = UserCreate(username=user_data['login'], email=user_data['email'])
 
         # Register user
         db_user = crud.get_user(db=db, user=user)


### PR DESCRIPTION
We should let the db handle the created_at timestamps as defined in models.py with
 `created_at = Column(DateTime(timezone=True), server_default=func.now())` 
The same mechanism should be used with updated_at too.
WDTY ?

(sorry I missed it when I reviewed)